### PR TITLE
pc - update so that when jacoco fails, the build fails

### DIFF
--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -25,4 +25,9 @@ jobs:
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test jacoco:report verify
-  
+    - name: Upload jacoco report to Artifacts
+      if: always() # always upload artifacts, even if tests fail
+      uses: actions/upload-artifact@v2
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/*

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -24,8 +24,5 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report 
-    - name: Upload to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+      run: mvn -B test jacoco:report verify
+  

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,7 +26,7 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn test org.pitest:pitest-maven:mutationCoverage
+      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100
     - name: Upload Pitest to Artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,7 +26,7 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 -DcoverageThreshold=100
+      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 
     - name: Upload Pitest to Artifacts
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v2

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,7 +26,7 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100
+      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 -DcoverageThreshold=100
     - name: Upload Pitest to Artifacts
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v2

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Pitest
       run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100
     - name: Upload Pitest to Artifacts
+      if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v2
       with:
         name: pitest-mutation-testing

--- a/pom.xml
+++ b/pom.xml
@@ -116,16 +116,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/edu/ucsb/cs156/courses/aop/LoggingAspect.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/config/*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendController.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendProxyController.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/services/CurrentUserServiceImpl.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/CoursesApplication.*</exclude>
-                    </excludes>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -139,7 +129,54 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+
+                        </configuration>
+                    </execution>
                 </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/edu/ucsb/cs156/courses/aop/LoggingAspect.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/config/*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendProxyController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/services/CurrentUserServiceImpl.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/CoursesApplication.*</exclude>
+                    </excludes>
+                </configuration>
+
             </plugin>
 
             <plugin>

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -14,9 +14,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Data
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Slf4j
 public class CoursePage {
     private int pageNumber;


### PR DESCRIPTION
In this PR from staff, we update the build so that if there isn't 100% test coverage on Jacoco, the build fails.