### PR TITLE
YL - Add String sourceRepo to systeminfo #12

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -19,4 +19,5 @@ public class SystemInfo {
   private Boolean showSwaggerUILink;
   private String startQtrYYYYQ;
   private String endQtrYYYYQ;
+  private String sourceRepo;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -27,12 +27,16 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.endQtrYYYYQ:20222}")
   private String endQtrYYYYQ;
 
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  private String sourceRepo;
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
     .startQtrYYYYQ(this.startQtrYYYYQ)
     .endQtrYYYYQ(this.endQtrYYYYQ)
+    .sourceRepo(this.sourceRepo)
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ springfox.documentation.swagger.v2.path=/api/docs
 spring.jpa.hibernate.ddl-auto=update
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
 
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-courses}}
+
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false
 


### PR DESCRIPTION
closes #12 Add String sourceRepo to systemInfo 

backend swagger /api/systemInfo response now contains the sourceRepo link:
<img width="1440" alt="Screen Shot 2022-11-20 at 1 40 38 PM" src="https://user-images.githubusercontent.com/86722488/202927946-263bbe67-4e5b-4454-8d7c-b7fbdb6c7936.png">

This can be tested by calling system-info-controller in swagger. Success if sourceRepo field and correct link are contained in the response body.
