### PR TITLE
YL - Modify footer to take value of source repo from /api/systemInfo instead of being hardcoded

### DIFF
--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -4,14 +4,16 @@ const systemInfoFixtures = {
         "springH2ConsoleEnabled": true,
         "showSwaggerUILink": true,
         "startQtrYYYYQ": "20084",
-        "endQtrYYYYQ": "20222"
+        "endQtrYYYYQ": "20222",
+        "sourceRepo": "https://github.com/ucsb-cs156/proj-courses"
     },
     showingNeither:
     {
         "springH2ConsoleEnabled": false,
         "showSwaggerUILink": false,
         "startQtrYYYYQ": "20084",
-        "endQtrYYYYQ": "20222"
+        "endQtrYYYYQ": "20222",
+        "sourceRepo": "https://github.com/ucsb-cs156/proj-courses"
     }
 };
 

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,8 +1,12 @@
 import { Container } from "react-bootstrap";
+import { useSystemInfo } from "main/utils/systemInfo";
 
 export const space=" ";
 
 export default function Footer() {
+
+  const { data: systemInfo } = useSystemInfo();
+
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
@@ -26,7 +30,7 @@ export default function Footer() {
       {space}
       <a
         data-testid="footer-source-code-link"
-        href="https://github.com/ucsb-cs156-s22/s22-4pm-courses"
+        href={systemInfo?.sourceRepo}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -30,7 +30,7 @@ export default function Footer() {
       {space}
       <a
         data-testid="footer-source-code-link"
-        href={systemInfo?.sourceRepo}
+        href={systemInfo.sourceRepo}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -13,7 +13,8 @@ export function useSystemInfo() {
         springH2ConsoleEnabled: false,
         showSwaggerUILink: false,
         startQtrYYYYQ: "20221",
-        endQtrYYYYQ: "20222"  
+        endQtrYYYYQ: "20222",
+        sourceRepo: "https://github.com/ucsb-cs156/proj-courses"  
       };
     }
   }, {
@@ -22,7 +23,8 @@ export function useSystemInfo() {
       springH2ConsoleEnabled: false,
       showSwaggerUILink: false,
       startQtrYYYYQ: "20221",
-      endQtrYYYYQ: "20222"  
+      endQtrYYYYQ: "20222",
+      sourceRepo: "https://github.com/ucsb-cs156/proj-courses"    
     }
   });
 

--- a/frontend/src/stories/components/Nav/Footer.stories.js
+++ b/frontend/src/stories/components/Nav/Footer.stories.js
@@ -1,0 +1,79 @@
+
+import React from 'react';
+
+import Footer from "main/components/Nav/Footer";
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
+
+export default {
+    title: 'components/Nav/Footer',
+    component: Footer
+};
+
+
+const Template = (args) => {
+    return (
+        <Footer {...args} />
+    )
+};
+
+export const basic_notLoggedIn = Template.bind({});
+
+
+export const basic_loggedInAdminUser = Template.bind({});
+basic_loggedInAdminUser.args = {
+    currentUser: currentUserFixtures.adminUser
+};
+
+export const basic_loggedInRegularUser = Template.bind({});
+basic_loggedInRegularUser.args = {
+    currentUser: currentUserFixtures.userOnly
+};
+
+export const extraLinks_neitherH2NorSwagger = Template.bind({});
+extraLinks_neitherH2NorSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingNeither
+};
+
+export const extraLinks_H2Only = Template.bind({});
+extraLinks_H2Only.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": true,
+        "showSwaggerUILink": false,
+        "sourceRepo": "https://github.com/ucsb-cs156/proj-courses",
+    }
+};
+
+export const extraLinks_SwaggerOnly = Template.bind({});
+extraLinks_SwaggerOnly.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": true,
+        "sourceRepo": "https://github.com/ucsb-cs156/proj-courses",
+    }
+};
+
+export const extraLinks_bothH2AndSwagger = Template.bind({});
+extraLinks_bothH2AndSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingBoth
+};
+
+
+export const localhost_3000 = Template.bind({});
+localhost_3000.args = {
+    currentUrl: "http://localhost:3000"
+};
+
+export const localhost_127_0_0_1__3000 = Template.bind({});
+localhost_127_0_0_1__3000.args = {
+    currentUrl: "http://127.0.0.1:3000"
+};
+
+export const localhost_8080 = Template.bind({});
+localhost_8080.args = {
+    currentUrl: "http://localhost:8080"
+};

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -23,7 +23,7 @@ describe("Footer tests", () => {
         );
         expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
           "href",
-          "https://github.com/ucsb-cs156-s22/s22-4pm-courses"
+          "https://github.com/ucsb-cs156/proj-courses"
         );
 
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,18 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import Footer, {space} from "main/components/Nav/Footer";
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 describe("Footer tests", () => {
+  const queryClient = new QueryClient()
     test("space stands for a space", () => {
         expect(space).toBe(" ");
       });
     
     
       test("renders without crashing", () => {
-        render(<Footer />);
+        render(
+          <QueryClientProvider client={queryClient}>
+            <Footer />
+          </QueryClientProvider>);
       });
     
       test("Links are correct", async () => {
-        render(<Footer />)
+        render(
+          <QueryClientProvider client={queryClient}>
+            <Footer />
+          </QueryClientProvider>)
         expect(screen.getByTestId("footer-class-website-link")).toHaveAttribute(
           "href",
           "https://ucsb-cs156.github.io"

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -34,7 +34,8 @@ describe("utils/systemInfo tests", () => {
                 springH2ConsoleEnabled: false,
                 showSwaggerUILink: false,
                 startQtrYYYYQ: "20221",
-                endQtrYYYYQ: "20222"  
+                endQtrYYYYQ: "20222",
+                sourceRepo: "https://github.com/ucsb-cs156/proj-courses"  
             });
             
             const queryState = queryClient.getQueryState("systemInfo");
@@ -95,7 +96,8 @@ describe("utils/systemInfo tests", () => {
                 springH2ConsoleEnabled: false,
                 showSwaggerUILink: false,
                 startQtrYYYYQ: "20221",
-                endQtrYYYYQ: "20222"
+                endQtrYYYYQ: "20222",
+                sourceRepo: "https://github.com/ucsb-cs156/proj-courses"  
             });
             queryClient.clear();
         });

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
@@ -35,6 +35,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .springH2ConsoleEnabled(true)
         .startQtrYYYYQ("20221")
         .endQtrYYYYQ("20222")
+        .sourceRepo("https://github.com/ucsb-cs156/proj-courses")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);
@@ -61,6 +62,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .springH2ConsoleEnabled(true)
         .startQtrYYYYQ("20221")
         .endQtrYYYYQ("20222")
+        .sourceRepo("https://github.com/ucsb-cs156/proj-courses")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);
@@ -86,6 +88,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .springH2ConsoleEnabled(true)
         .startQtrYYYYQ("20221")
         .endQtrYYYYQ("20222")
+        .sourceRepo("https://github.com/ucsb-cs156/proj-courses")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);


### PR DESCRIPTION
closes #15 Modify footer to take value of source repo from /api/systemInfo instead of being hardcoded

Changed the GitHub link in footer to get link from api/systemInfo. Now it directs to the correct repo page https://github.com/ucsb-cs156/proj-courses

Modified tests and storybook for footer

<img width="1440" alt="Screenshot 2022-11-21 at 7 31 59 PM" src="https://user-images.githubusercontent.com/86722488/203215842-acaeffad-6316-48dc-a120-418da2f86f2f.png">

