### PR TITLE
VL - Adjust PSCourse post method to add both primary and secondary

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -137,12 +137,10 @@ public class PSCourseController extends ApiController {
             String section = node.path("section").asText();
             if (section.endsWith("00")) {
                 enrollCdPrimary = node.path("enrollCode").asText();
-                if (hasSecondary) {
-                    break;
-                }
             }
             else {
                 hasSecondary = true;
+                break;
             }
         }
 
@@ -151,26 +149,28 @@ public class PSCourseController extends ApiController {
             hasSecondary = false;
         }
 
-        if (enrollCdPrimary == enrollCd && hasSecondary) {
+        if (enrollCdPrimary.equals(enrollCd) && hasSecondary) {
             throw new IllegalArgumentException(enrollCd + " is for a course with sections; please add a specific section and the lecture will be automatically added");
         }
 
         ArrayList<PSCourse> savedCourses = new ArrayList<>();
 
-        PSCourse secondary = new PSCourse();
-        secondary.setUser(currentUser.getUser());
-        secondary.setEnrollCd(enrollCd);
-        secondary.setPsId(psId);
-        PSCourse saved = coursesRepository.save(secondary);
-        savedCourses.add(saved);
-
         PSCourse primary = new PSCourse();
         primary.setUser(currentUser.getUser());
         primary.setEnrollCd(enrollCdPrimary);
         primary.setPsId(psId);
-        saved = coursesRepository.save(primary);
+        PSCourse saved = coursesRepository.save(primary);
         savedCourses.add(saved);
-        
+
+        if (hasSecondary) {
+            PSCourse secondary = new PSCourse();
+            secondary.setUser(currentUser.getUser());
+            secondary.setEnrollCd(enrollCd);
+            secondary.setPsId(psId);
+            saved = coursesRepository.save(secondary);
+            savedCourses.add(saved);
+        }
+
         return savedCourses;
     }
 

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -59,6 +59,8 @@ public class UCSBCurriculumService {
 
     public static final String SECTION_ENDPOINT = "https://api.ucsb.edu/academics/curriculums/v1/classsection/{quarter}/{enrollcode}";
 
+    public static final String ALL_SECTIONS_ENDPOINT = "https://api.ucsb.edu/academics/curriculums/v1/classes/{quarter}/{enrollcode}";
+
     public String getJSON(String subjectArea, String quarter, String courseLevel) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -153,6 +155,51 @@ public class UCSBCurriculumService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String url = SECTION_ENDPOINT;
+
+
+        logger.info("url=" + url);
+
+        String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
+        .queryParam("quarter", "{quarter}")
+        .queryParam("enrollcode", "{enrollcode}")
+        .encode()
+        .toUriString();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("quarter", quarter);
+        params.put("enrollcode", enrollCode);
+
+        String retVal = "";
+        MediaType contentType = null;
+        HttpStatus statusCode = null;
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class, params);
+            contentType = re.getHeaders().getContentType();
+            statusCode = re.getStatusCode();
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+
+        if(retVal.equals("null")){
+            retVal = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
+        }
+
+        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        return retVal;
+    }
+
+    public String getAllSections(String enrollCode, String quarter) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "1.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String url = ALL_SECTIONS_ENDPOINT;
 
 
         logger.info("url=" + url);

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
@@ -60,6 +60,307 @@ public class SectionFixtures {
       ]
     }
       """;
+  
+  public static final String SECTION_JSON_CMPSC156 = """
+    {
+      "quarter": "20224",
+      "courseId": "CMPSC   156  ",
+      "title": "ADV APP PROGRAM",
+      "contactHours": 30,
+      "description": "Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenanc e tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.",
+      "college": "ENGR",
+      "objLevelCode": "U",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "58891",
+          "section": "0100",
+          "session": null,
+          "classClosed": "Y",
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 72,
+          "maxEnroll": 72,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1431",
+              "building": "SH",
+              "roomCapacity": 76,
+              "days": " T R   ",
+              "beginTime": "17:00",
+              "endTime": "18:15"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "CONRAD P T",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        },
+        {
+          "enrollCode": "58909",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 24,
+          "maxEnroll": 24,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "  W    ",
+              "beginTime": "17:00",
+              "endTime": "17:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "DE A",
+              "functionCode": "Teaching but not in charge"
+            },
+            {
+              "instructor": "ROSS V E",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        },
+        {
+          "enrollCode": "58917",
+          "section": "0102",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 24,
+          "maxEnroll": 24,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "  W    ",
+              "beginTime": "18:00",
+              "endTime": "18:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "ROSS V E",
+              "functionCode": "Teaching but not in charge"
+            },
+            {
+              "instructor": "DE A",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        },
+        {
+          "enrollCode": "58925",
+          "section": "0103",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 24,
+          "maxEnroll": 24,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "  W    ",
+              "beginTime": "19:00",
+              "endTime": "19:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "DE A",
+              "functionCode": "Teaching but not in charge"
+            },
+            {
+              "instructor": "ROSS V E",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        }
+      ]
+    }
+      """;
+
+  public static final String SECTION_JSON_ENGL110A = """
+    {
+      "quarter": "20224",
+      "courseId": "ENGL    110A ",
+      "title": "INTRO TO OLD ENGL",
+      "contactHours": 30,
+      "description": "Introduction to Old English language and literature. Students learn to read and translate a selection of prose and verse works. A full description for any given quarter will be available on the English Department's website.",
+      "college": "L&S",
+      "objLevelCode": "U",
+      "subjectArea": "ENGL    ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": null,
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "ENGL ",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "50914",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 28,
+          "maxEnroll": 38,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "U",
+          "restrictionMajor": "+ENGL +CLIT +WTLCS+LING +GERLL+GERM +MDVST+HIST",
+          "restrictionMajorPass": "1",
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [
+            "ENGL    205A 0100"
+          ],
+          "timeLocations": [
+            {
+              "room": "2532",
+              "building": "PHELP",
+              "roomCapacity": 40,
+              "days": "M W    ",
+              "beginTime": "14:00",
+              "endTime": "15:15"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "REEVE D J",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+      ]
+    }
+      """;
+
+  public static final String SECTION_JSON_INVALID = """
+    {
+      "quarter": "20224",
+      "courseId": "ENGL    110A ",
+      "title": "INTRO TO OLD ENGL",
+      "contactHours": 30,
+      "description": "Introduction to Old English language and literature. Students learn to read and translate a selection of prose and verse works. A full description for any given quarter will be available on the English Department's website.",
+      "college": "L&S",
+      "objLevelCode": "U",
+      "subjectArea": "ENGL    ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": null,
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "ENGL ",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "50914",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 28,
+          "maxEnroll": 38,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "U",
+          "restrictionMajor": "+ENGL +CLIT +WTLCS+LING +GERLL+GERM +MDVST+HIST",
+          "restrictionMajorPass": "1",
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [
+            "ENGL    205A 0100"
+          ],
+          "timeLocations": [
+            {
+              "room": "2532",
+              "building": "PHELP",
+              "roomCapacity": 40,
+              "days": "M W    ",
+              "beginTime": "14:00",
+              "endTime": "15:15"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "REEVE D J",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+      ]
+    }
+      """;
 
 }
   

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -326,4 +326,67 @@ public class UCSBCurriculumServiceTests {
         assertEquals(expectedResult, result);
     }
 
+    @Test
+    public void test_getAllSections_success() throws Exception {
+        String expectedResult = SectionFixtures.SECTION_JSON_CMPSC156;
+
+        String enrollCode = "58909";
+        String quarter = "20224";
+
+        String expectedURL = UCSBCurriculumService.ALL_SECTIONS_ENDPOINT.replace("{quarter}", quarter).replace("{enrollcode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getAllSections(enrollCode, quarter);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getAllSections_exception() throws Exception {
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+
+        String enrollCode = "58909";
+        String quarter = "20224";
+
+        String expectedURL = UCSBCurriculumService.ALL_SECTIONS_ENDPOINT.replace("{quarter}", quarter).replace("{enrollcode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withUnauthorizedRequest());
+
+        String result = ucs.getAllSections(enrollCode, quarter);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getAllSections_not_found() throws Exception {
+        String expectedResult = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
+
+
+        String enrollCode = "58909";
+        String quarter = "00000";
+
+        String expectedURL = UCSBCurriculumService.ALL_SECTIONS_ENDPOINT.replace("{quarter}", quarter).replace("{enrollcode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+        String result = ucs.getAllSections(enrollCode, quarter);
+        assertEquals(expectedResult, result);
+    }
+    
 }


### PR DESCRIPTION
Adjusted the PSCourse post method to allow adding both the primary and secondary on enrolling in secondary. Handles the various cases specified in the issue.
Closes #17 
![image](https://user-images.githubusercontent.com/77411328/203622707-4588cc51-5184-4fb3-add3-3545be2bc247.png)
![image](https://user-images.githubusercontent.com/77411328/203622814-e28c75b1-2cd4-4a50-9be0-9505fb0f03ed.png)
![image](https://user-images.githubusercontent.com/77411328/203622894-21d10f43-a7cd-4f46-82ff-1d5a962f590c.png)
![image](https://user-images.githubusercontent.com/77411328/203622938-caecc804-b9cf-47e6-a251-cfbb2702ed90.png)
