### PR TITLE
VL - Bug Fix: adjust PSCourse post method to add both primary and secondary 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -203,7 +203,7 @@ public class UCSBCurriculumService {
         String url = ALL_SECTIONS_ENDPOINT;
 
 
-        logger.info("url=" + url);
+        log.info("url=" + url);
 
         String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
         .queryParam("quarter", "{quarter}")
@@ -231,7 +231,7 @@ public class UCSBCurriculumService {
             retVal = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
         }
 
-        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
     }
      


### PR DESCRIPTION
Apparently someone removed a humble logger variable from `UCSBCurriculumService.java` when I was working on the file in the meantime, causing all the tests to fail miserably. Rebased my branch and opened a new pr to fix this.