### PR TITLE
CVS - modified delete function

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -224,24 +224,26 @@ public class PSCourseController extends ApiController {
                   break;
               }
           }
-          String output;
+          String output = "";
           if (!hasSecondary) { 
               coursesRepository.delete(course);
               return genericMessage("PSCourse with id %s deleted".formatted(id));
           }
+          PSCourse primaryCourse = coursesRepository.findById(primaryId).get();
+          coursesRepository.delete(primaryCourse);
           if (enrollmentCode.equals(primaryCode)) {
               Iterator<JsonNode> allSections2 = mapper.readTree(body).path("classSections").elements();
               Iterable<PSCourse> currentCourses = thisUsersCoursesForPsId(course.getPsId());
               boolean done = false;
-              while (allSections2.hasNext() && !done) {
+              while (!done) {
                 JsonNode node2 = allSections2.next();
                 String sectionCodes = node2.path("enrollCode").asText();
                 if (!sectionCodes.equals(primaryCode)){
                     for (PSCourse psc: currentCourses) {
                         if (psc.getEnrollCd().equals(sectionCodes)) {
+                            log.info("banana");
                             secondaryId = psc.getId();
                             done = true;
-                            break;
                         }
                     }
                 }
@@ -250,9 +252,7 @@ public class PSCourseController extends ApiController {
           } else {
             output = "PSCourse with id %s and matching primary with id %s deleted".formatted(secondaryId, primaryId);
           }
-        PSCourse primaryCourse = coursesRepository.findById(primaryId).get();
         PSCourse secondaryCourse = coursesRepository.findById(secondaryId).get();
-        coursesRepository.delete(primaryCourse);
         coursesRepository.delete(secondaryCourse);
         return genericMessage(output);
     }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -191,12 +191,147 @@ public class PSCourseController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("/user")
     public Object deleteCourses(
-            @ApiParam("id") @RequestParam Long id) {
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
         User currentUser = getCurrentUser().getUser();
-        PSCourse courses = coursesRepository.findByIdAndUser(id, currentUser)
+        PSCourse course = coursesRepository.findByIdAndUser(id, currentUser)
           .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
-        coursesRepository.delete(courses);
-        return genericMessage("PSCourse with id %s deleted".formatted(id));
+          String enrollmentCode = course.getEnrollCd();
+
+          PersonalSchedule checkPsId = personalScheduleRepository.findByIdAndUser(course.getPsId(), currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, course.getPsId()));
+  
+          String body = ucsbCurriculumService.getAllSections(enrollmentCode, checkPsId.getQuarter());
+  
+          // WAS ATTEMPTING ANOTHER WAY, DIDN'T WORK, ALSO STILL RAN INTO SAME ISSUES WHEN DOING mvn test AS CURRENT METHOD DOES
+          //String primaryCode = null;
+          // Long primaryId = id;
+          // Long secondaryId = id;
+          // String tester = ucsbCurriculumService.getSection(enrollmentCode, checkPsId.getQuarter());
+          // JsonNode testSection = mapper.readTree(tester).path("classSections").elements().next();
+          // String section = testSection.path("section").asText();
+          // String isSecondary = testSection.path("secondaryStatus").asText();
+          // String output = "poop";
+          // if (section.endsWith("00") && isSecondary.equals("null")) { //Lecture with no section
+          //     output = "Lecture with no section";
+          //     coursesRepository.delete(course);
+          //     return genericMessage("PSCourse with id %s deleted".formatted(id));
+          // } else if (section.endsWith("00")) { //Lecture with section
+          //     Iterator<JsonNode> allSections = mapper.readTree(body).path("classSections").elements();
+          //     while (allSections.hasNext()) {
+          //         JsonNode node = allSections.next();
+          //         String diffSection = node.path("section").asText();
+          //         String primaryCode = null;
+          //         if (diffSection.endsWith("00")) {
+          //             primaryCode = node.path("enrollCode").asText();
+          //             Iterable<PSCourse> userCourses = thisUsersCoursesForPsId(course.getPsId());
+          //             for (PSCourse psc: userCourses) {
+          //                 if (psc.getEnrollCd().equals(primaryCode)) {
+          //                     primaryId = psc.getId();
+          //                 }
+          //             }
+          //         } else {
+          //             break;
+          //         }
+          //     }
+          //     final Long id1 = primaryId;
+          //     final Long id2 = secondaryId;
+          //     PSCourse primaryCourse = coursesRepository.findById(primaryId)
+          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
+          //     PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
+          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
+          //     coursesRepository.delete(primaryCourse);
+          //     coursesRepository.delete(secondaryCourse);
+          //     return genericMessage("PSCourse with id %s and matching primary with id %s deleted".formatted(secondaryId, primaryId));
+          // } else { //Section with lecture
+          //     Iterator<JsonNode> allSections2 = mapper.readTree(body).path("classSections").elements();
+          //     Iterable<PSCourse> currentCourses = thisUsersCoursesForPsId(course.getPsId());
+          //     while (allSections2.hasNext()) {
+          //         JsonNode node2 = allSections2.next();
+          //         String sectionCodes = node2.path("enrollCode").asText();
+          //         for (PSCourse psc: currentCourses) {
+          //             if (psc.getEnrollCd().equals(sectionCodes)) {
+          //                 secondaryId = psc.getId();
+          //             }
+          //         }
+          //     }
+          //     final Long id1 = primaryId;
+          //     final Long id2 = secondaryId;
+          //     PSCourse primaryCourse = coursesRepository.findById(primaryId)
+          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
+          //     PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
+          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
+          //     coursesRepository.delete(primaryCourse);
+          //     coursesRepository.delete(secondaryCourse);
+          //     return genericMessage("PSCourse with id %s and matching secondary with id %s deleted".formatted(primaryId, secondaryId));
+          // }
+          //return genericMessage(tester);
+          //JsonNode currentSection = ;
+  
+          Long primaryId = id;
+          Long secondaryId = id;
+          String primaryCode = null;
+          boolean hasSecondary = false;
+          Iterator<JsonNode> allSections = mapper.readTree(body).path("classSections").elements(); //believes this is source of nestserlet issues for mvn test, don't know why
+  
+          while (allSections.hasNext()) {
+              JsonNode node = allSections.next();
+              String section = node.path("section").asText();
+              if (section.endsWith("00")) {
+                  primaryCode = node.path("enrollCode").asText();
+                  Iterable<PSCourse> userCourses = thisUsersCoursesForPsId(course.getPsId());
+                  for (PSCourse psc: userCourses) {
+                      if (psc.getEnrollCd().equals(primaryCode)) {
+                          primaryId = psc.getId();
+                      }
+                  }
+              }
+              else {
+                  hasSecondary = true;
+                  break;
+              }
+          }
+  
+          if (primaryCode == null) {
+              primaryCode = enrollmentCode;
+              hasSecondary = false;
+          }
+  
+          if (!hasSecondary) { //lecture is given, has no sectios, just delete lecture
+              coursesRepository.delete(course);
+              return genericMessage("PSCourse with id %s deleted".formatted(id));
+          }
+          if (enrollmentCode.equals(primaryCode)) { //given id of lecture, delete lecture and find and delete associated section NOT WORKING (NEED TO FIND SECTION)
+              Iterator<JsonNode> allSections2 = mapper.readTree(body).path("classSections").elements();
+              Iterable<PSCourse> currentCourses = thisUsersCoursesForPsId(course.getPsId());
+              while (allSections2.hasNext()) {
+                  JsonNode node2 = allSections2.next();
+                  String sectionCodes = node2.path("enrollCode").asText();
+                  for (PSCourse psc: currentCourses) {
+                      if (psc.getEnrollCd().equals(sectionCodes)) {
+                          secondaryId = psc.getId();
+                      }
+                  }
+              }
+              final Long id1 = primaryId;
+              final Long id2 = secondaryId;
+              PSCourse primaryCourse = coursesRepository.findById(primaryId)
+              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
+              PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
+              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
+              coursesRepository.delete(primaryCourse);
+              coursesRepository.delete(secondaryCourse);
+              return genericMessage("PSCourse with id %s and matching secondary with id %s deleted".formatted(primaryId, secondaryId));
+          } else { //given id of section, delete section and find and delete associated lecture
+              final Long id1 = primaryId;
+              final Long id2 = secondaryId;
+              PSCourse primaryCourse = coursesRepository.findById(primaryId)
+              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
+              PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
+              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
+              coursesRepository.delete(primaryCourse);
+              coursesRepository.delete(secondaryCourse);
+              return genericMessage("PSCourse with id %s and matching primary with id %s deleted".formatted(secondaryId, primaryId));
+          }
     }
 
     @ApiOperation(value = "Update a single Course (admin)")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -241,7 +241,6 @@ public class PSCourseController extends ApiController {
                 if (!sectionCodes.equals(primaryCode)){
                     for (PSCourse psc: currentCourses) {
                         if (psc.getEnrollCd().equals(sectionCodes)) {
-                            log.info("banana");
                             secondaryId = psc.getId();
                             done = true;
                         }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -202,77 +202,11 @@ public class PSCourseController extends ApiController {
   
           String body = ucsbCurriculumService.getAllSections(enrollmentCode, checkPsId.getQuarter());
   
-          // WAS ATTEMPTING ANOTHER WAY, DIDN'T WORK, ALSO STILL RAN INTO SAME ISSUES WHEN DOING mvn test AS CURRENT METHOD DOES
-          //String primaryCode = null;
-          // Long primaryId = id;
-          // Long secondaryId = id;
-          // String tester = ucsbCurriculumService.getSection(enrollmentCode, checkPsId.getQuarter());
-          // JsonNode testSection = mapper.readTree(tester).path("classSections").elements().next();
-          // String section = testSection.path("section").asText();
-          // String isSecondary = testSection.path("secondaryStatus").asText();
-          // String output = "poop";
-          // if (section.endsWith("00") && isSecondary.equals("null")) { //Lecture with no section
-          //     output = "Lecture with no section";
-          //     coursesRepository.delete(course);
-          //     return genericMessage("PSCourse with id %s deleted".formatted(id));
-          // } else if (section.endsWith("00")) { //Lecture with section
-          //     Iterator<JsonNode> allSections = mapper.readTree(body).path("classSections").elements();
-          //     while (allSections.hasNext()) {
-          //         JsonNode node = allSections.next();
-          //         String diffSection = node.path("section").asText();
-          //         String primaryCode = null;
-          //         if (diffSection.endsWith("00")) {
-          //             primaryCode = node.path("enrollCode").asText();
-          //             Iterable<PSCourse> userCourses = thisUsersCoursesForPsId(course.getPsId());
-          //             for (PSCourse psc: userCourses) {
-          //                 if (psc.getEnrollCd().equals(primaryCode)) {
-          //                     primaryId = psc.getId();
-          //                 }
-          //             }
-          //         } else {
-          //             break;
-          //         }
-          //     }
-          //     final Long id1 = primaryId;
-          //     final Long id2 = secondaryId;
-          //     PSCourse primaryCourse = coursesRepository.findById(primaryId)
-          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
-          //     PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
-          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
-          //     coursesRepository.delete(primaryCourse);
-          //     coursesRepository.delete(secondaryCourse);
-          //     return genericMessage("PSCourse with id %s and matching primary with id %s deleted".formatted(secondaryId, primaryId));
-          // } else { //Section with lecture
-          //     Iterator<JsonNode> allSections2 = mapper.readTree(body).path("classSections").elements();
-          //     Iterable<PSCourse> currentCourses = thisUsersCoursesForPsId(course.getPsId());
-          //     while (allSections2.hasNext()) {
-          //         JsonNode node2 = allSections2.next();
-          //         String sectionCodes = node2.path("enrollCode").asText();
-          //         for (PSCourse psc: currentCourses) {
-          //             if (psc.getEnrollCd().equals(sectionCodes)) {
-          //                 secondaryId = psc.getId();
-          //             }
-          //         }
-          //     }
-          //     final Long id1 = primaryId;
-          //     final Long id2 = secondaryId;
-          //     PSCourse primaryCourse = coursesRepository.findById(primaryId)
-          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
-          //     PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
-          //     .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
-          //     coursesRepository.delete(primaryCourse);
-          //     coursesRepository.delete(secondaryCourse);
-          //     return genericMessage("PSCourse with id %s and matching secondary with id %s deleted".formatted(primaryId, secondaryId));
-          // }
-          //return genericMessage(tester);
-          //JsonNode currentSection = ;
-  
           Long primaryId = id;
           Long secondaryId = id;
           String primaryCode = null;
           boolean hasSecondary = false;
-          Iterator<JsonNode> allSections = mapper.readTree(body).path("classSections").elements(); //believes this is source of nestserlet issues for mvn test, don't know why
-  
+          Iterator<JsonNode> allSections = mapper.readTree(body).path("classSections").elements();
           while (allSections.hasNext()) {
               JsonNode node = allSections.next();
               String section = node.path("section").asText();
@@ -290,48 +224,37 @@ public class PSCourseController extends ApiController {
                   break;
               }
           }
-  
-          if (primaryCode == null) {
-              primaryCode = enrollmentCode;
-              hasSecondary = false;
-          }
-  
-          if (!hasSecondary) { //lecture is given, has no sectios, just delete lecture
+          String output;
+          if (!hasSecondary) { 
               coursesRepository.delete(course);
               return genericMessage("PSCourse with id %s deleted".formatted(id));
           }
-          if (enrollmentCode.equals(primaryCode)) { //given id of lecture, delete lecture and find and delete associated section NOT WORKING (NEED TO FIND SECTION)
+          if (enrollmentCode.equals(primaryCode)) {
               Iterator<JsonNode> allSections2 = mapper.readTree(body).path("classSections").elements();
               Iterable<PSCourse> currentCourses = thisUsersCoursesForPsId(course.getPsId());
-              while (allSections2.hasNext()) {
-                  JsonNode node2 = allSections2.next();
-                  String sectionCodes = node2.path("enrollCode").asText();
-                  for (PSCourse psc: currentCourses) {
-                      if (psc.getEnrollCd().equals(sectionCodes)) {
-                          secondaryId = psc.getId();
-                      }
-                  }
+              boolean done = false;
+              while (allSections2.hasNext() && !done) {
+                JsonNode node2 = allSections2.next();
+                String sectionCodes = node2.path("enrollCode").asText();
+                if (!sectionCodes.equals(primaryCode)){
+                    for (PSCourse psc: currentCourses) {
+                        if (psc.getEnrollCd().equals(sectionCodes)) {
+                            secondaryId = psc.getId();
+                            done = true;
+                            break;
+                        }
+                    }
+                }
               }
-              final Long id1 = primaryId;
-              final Long id2 = secondaryId;
-              PSCourse primaryCourse = coursesRepository.findById(primaryId)
-              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
-              PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
-              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
-              coursesRepository.delete(primaryCourse);
-              coursesRepository.delete(secondaryCourse);
-              return genericMessage("PSCourse with id %s and matching secondary with id %s deleted".formatted(primaryId, secondaryId));
-          } else { //given id of section, delete section and find and delete associated lecture
-              final Long id1 = primaryId;
-              final Long id2 = secondaryId;
-              PSCourse primaryCourse = coursesRepository.findById(primaryId)
-              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id1));
-              PSCourse secondaryCourse = coursesRepository.findById(secondaryId)
-              .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id2));
-              coursesRepository.delete(primaryCourse);
-              coursesRepository.delete(secondaryCourse);
-              return genericMessage("PSCourse with id %s and matching primary with id %s deleted".formatted(secondaryId, primaryId));
+              output = "PSCourse with id %s and matching secondary with id %s deleted".formatted(primaryId, secondaryId);
+          } else {
+            output = "PSCourse with id %s and matching primary with id %s deleted".formatted(secondaryId, primaryId);
           }
+        PSCourse primaryCourse = coursesRepository.findById(primaryId).get();
+        PSCourse secondaryCourse = coursesRepository.findById(secondaryId).get();
+        coursesRepository.delete(primaryCourse);
+        coursesRepository.delete(secondaryCourse);
+        return genericMessage(output);
     }
 
     @ApiOperation(value = "Update a single Course (admin)")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,9 +14,6 @@ spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:$
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:${env.GOOGLE_CLIENT_SECRET:client_secret_unset}}
 spring.security.oauth2.client.registration.google.scope=email,profile
 
-#helps MONGODB stuff
-spring.data.mongodb.database=cs156-6pm-2-courses-project
-
 management.endpoints.web.exposure.include=mappings
 springfox.documentation.swagger.v2.path=/api/docs
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -580,6 +580,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
         when(coursesRepository.findByIdAndUser(eq(18L), eq(u))).thenReturn(Optional.of(expectedSection));
         when(coursesRepository.findById(eq(18L))).thenReturn(Optional.of(expectedSection));
 
+        PSCourse expectedCourses = PSCourse.builder().enrollCd("08268").psId(2L).user(u).id(19L).build();
+
         when(ucsbCurriculumService.getAllSections(eq("58891"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC156);
         
         ArrayList<PSCourse> expectedResponse = new ArrayList<>();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -512,20 +512,17 @@ public class PSCourseControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "USER" })
     @Test
-    public void api_courses__user_logged_in__delete_lecture_with_no_section() throws Exception { //Working on
+    public void api_courses__user_logged_in__delete_lecture_with_no_section() throws Exception {
         // arrange
 
         User u = currentUserService.getCurrentUser().getUser();
         PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
         when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
 
-        PSCourse expectedCourses = PSCourse.builder().enrollCd("50914").psId(1L).user(u).id(15L).build();
-        when(coursesRepository.save(eq(expectedCourses))).thenReturn(expectedCourses);
+        PSCourse expectedCourses = PSCourse.builder().enrollCd("08268").psId(1L).user(u).id(15L).build();
         when(coursesRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(expectedCourses));
-        ArrayList<PSCourse> expectedResponse = new ArrayList<>();
-        expectedResponse.add(expectedCourses);
 
-        when(ucsbCurriculumService.getAllSections(eq("50914"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_ENGL110A);
+        when(ucsbCurriculumService.getAllSections(eq("08268"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC165B);
 
         // act
         MvcResult response = mockMvc.perform(
@@ -542,43 +539,107 @@ public class PSCourseControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "USER" })
     @Test
-    public void api_courses__user_logged_in__delete_lecture_with_section() throws Exception { //Has issue
+    public void api_courses__user_logged_in__delete_lecture_with_no_section_invalid_PSId() throws Exception {
         // arrange
 
         User u = currentUserService.getCurrentUser().getUser();
         PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
         when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
 
-        PSCourse expectedLecture = PSCourse.builder().enrollCd("58891").psId(1L).user(u).id(15L).build();
-        when(coursesRepository.save(eq(expectedLecture))).thenReturn(expectedLecture);
-        when(coursesRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(expectedLecture));
-        
-        PSCourse expectedSection = PSCourse.builder().enrollCd("58909").psId(1L).user(u).id(16L).build();
-        when(coursesRepository.save(eq(expectedSection))).thenReturn(expectedSection);
-        when(coursesRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(expectedSection));
-        
-        ArrayList<PSCourse> expectedResponse = new ArrayList<>();
-        expectedResponse.add(expectedLecture);
-        expectedResponse.add(expectedSection);
+        PSCourse expectedCourses = PSCourse.builder().enrollCd("08268").psId(2L).user(u).id(15L).build();
+        when(coursesRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(expectedCourses));
 
-        when(ucsbCurriculumService.getAllSections(eq("58891"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC156);
+        when(ucsbCurriculumService.getAllSections(eq("08268"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC165B);
 
         // act
         MvcResult response = mockMvc.perform(
                 delete("/api/courses/user?id=15")
                         .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+                .andExpect(status().isNotFound()).andReturn();
 
         // assert
         verify(coursesRepository, times(1)).findByIdAndUser(15L, u);
-        verify(coursesRepository, times(1)).delete(expectedLecture);
-        verify(coursesRepository, times(1)).findByIdAndUser(16L, u);
-        verify(coursesRepository, times(1)).delete(expectedSection);
         Map<String, Object> json = responseToJson(response);
-        assertEquals("PSCourse with id 15 and matching secondary with id 16 deleted", json.get("message"));
+        assertEquals("PersonalSchedule with id 2 not found", json.get("message"));
     }
 
-    //Going to add 3rd test which is delete section with lecture
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_courses__user_logged_in__delete_lecture_with_section() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
+        when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
+
+        PSCourse expectedLecture = PSCourse.builder().enrollCd("58891").psId(1L).user(u).id(17L).build();
+        when(coursesRepository.findByIdAndUser(eq(17L), eq(u))).thenReturn(Optional.of(expectedLecture));
+        when(coursesRepository.findById(eq(17L))).thenReturn(Optional.of(expectedLecture));
+        
+        PSCourse expectedSection = PSCourse.builder().enrollCd("58909").psId(1L).user(u).id(18L).build();
+        when(coursesRepository.findByIdAndUser(eq(18L), eq(u))).thenReturn(Optional.of(expectedSection));
+        when(coursesRepository.findById(eq(18L))).thenReturn(Optional.of(expectedSection));
+
+        when(ucsbCurriculumService.getAllSections(eq("58891"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC156);
+        
+        ArrayList<PSCourse> expectedResponse = new ArrayList<>();
+        expectedResponse.add(expectedLecture);
+        expectedResponse.add(expectedSection);
+        when(coursesRepository.findAllByPsIdAndUser(eq(1L), eq(u))).thenReturn(expectedResponse);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/courses/user?id=17")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(coursesRepository, times(1)).findByIdAndUser(17L, u);
+        verify(coursesRepository, times(1)).findById(17L);
+        verify(coursesRepository, times(1)).delete(eq(expectedLecture));
+        verify(coursesRepository, times(1)).delete(eq(expectedSection));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("PSCourse with id 17 and matching secondary with id 18 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_courses__user_logged_in__delete_section_with_lecture() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
+        when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
+
+        PSCourse expectedLecture = PSCourse.builder().enrollCd("58891").psId(1L).user(u).id(17L).build();
+        when(coursesRepository.findByIdAndUser(eq(17L), eq(u))).thenReturn(Optional.of(expectedLecture));
+        when(coursesRepository.findById(eq(17L))).thenReturn(Optional.of(expectedLecture));
+        
+        PSCourse expectedSection = PSCourse.builder().enrollCd("58909").psId(1L).user(u).id(18L).build();
+        when(coursesRepository.findByIdAndUser(eq(18L), eq(u))).thenReturn(Optional.of(expectedSection));
+        when(coursesRepository.findById(eq(18L))).thenReturn(Optional.of(expectedSection));
+
+        when(ucsbCurriculumService.getAllSections(eq("58909"), eq("20224"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC156);
+        
+        ArrayList<PSCourse> expectedResponse = new ArrayList<>();
+        expectedResponse.add(expectedLecture);
+        expectedResponse.add(expectedSection);
+        when(coursesRepository.findAllByPsIdAndUser(eq(1L), eq(u))).thenReturn(expectedResponse);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/courses/user?id=18")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(coursesRepository, times(1)).findByIdAndUser(18L, u);
+        verify(coursesRepository, times(1)).findById(18L);
+        verify(coursesRepository, times(1)).delete(eq(expectedLecture));
+        verify(coursesRepository, times(1)).delete(eq(expectedSection));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("PSCourse with id 18 and matching primary with id 17 deleted", json.get("message"));
+    }
 
     @WithMockUser(roles = { "USER" })
     @Test


### PR DESCRIPTION
Delete function now deletes lecture and associated section and vice versa. Closes #19 
Deleting the lecture and having the section be automatically deleted:
<img width="622" alt="Screen Shot 2022-11-29 at 7 56 40 PM" src="https://user-images.githubusercontent.com/72837831/204704374-e94aa961-70c8-416d-a140-c33f4cee176d.png">

Deleting the section and having the lecture be automatically deleted:
<img width="577" alt="Screen Shot 2022-11-29 at 7 57 14 PM" src="https://user-images.githubusercontent.com/72837831/204704443-55a0a43b-0f6e-4fbd-b731-78e4c76ed075.png">

Deleting a lecture that has no sections:
<img width="348" alt="Screen Shot 2022-11-29 at 7 57 42 PM" src="https://user-images.githubusercontent.com/72837831/204704485-68a43368-bbe7-44fe-9966-b20b9f1c9dc8.png">

