### PR TITLE
YL - Course Over Time Backend Part One and Part Two

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.collections;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -12,4 +13,8 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 public interface ConvertedSectionCollection extends MongoRepository<ConvertedSection, ObjectId> {
     @Query("{'courseInfo.quarter': ?0, 'section.enrollCode': ?1}")
     Optional<ConvertedSection> findOneByQuarterAndEnrollCode(String quarter, String enrollCode);
+
+    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'courseInfo.courseId': { $regex: ?2 }}")
+    List<ConvertedSection> findCourseOverTime(String startQuarter, String endQuarter, String courseId);
 }
+

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -33,14 +33,14 @@ public class CourseOverTimeController {
 
     @GetMapping(value = "/search", produces = "application/json")
     public ResponseEntity<String> search(
-        @RequestParam String startQtr,
-        @RequestParam String endQtr,
+        @RequestParam String startQuarter,
+        @RequestParam String endQuarter,
         @RequestParam String subject,
         @RequestParam String number) 
         
         throws JsonProcessingException {
 
-        List<ConvertedSection> course = convertedSectionCollection.findCourseOverTime(startQtr,endQtr,makeFormattedCourseId(subject, number));
+        List<ConvertedSection> course = convertedSectionCollection.findCourseOverTime(startQuarter,endQuarter,makeFormattedCourseId(subject, number));
         String body = mapper.writeValueAsString(course);
         return ResponseEntity.ok().body(body);
     }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -1,0 +1,64 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/public/courseovertime")
+public class CourseOverTimeController {
+
+    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeController.class);
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @GetMapping(value = "/search", produces = "application/json")
+    public ResponseEntity<String> search(
+        @RequestParam String startQtr,
+        @RequestParam String endQtr,
+        @RequestParam String subject,
+        @RequestParam String number) 
+        
+        throws JsonProcessingException {
+
+        List<ConvertedSection> course = convertedSectionCollection.findCourseOverTime(startQtr,endQtr,makeFormattedCourseId(subject, number));
+        String body = mapper.writeValueAsString(course);
+        return ResponseEntity.ok().body(body);
+    }
+
+    String makeFormattedCourseId(String subjectArea, String courseNumber) {
+        String[] nums = courseNumber.split("[a-zA-Z]+");
+        String[] suffs = courseNumber.split("[0-9]+");
+        if (suffs.length < 2) { // no suffix
+            return
+                  String.format( "%-8s", subjectArea                ) // 'CMPSC   '
+                + String.format( "%3s" , nums[0]                    ) // '  8'
+            ;
+        }
+        return
+              String.format( "%-8s", subjectArea                ) // 'CMPSC   '
+            + String.format( "%3s" , nums[0]                    ) // '  8'
+            + String.format( "%-2s", suffs[1]                   ) // 'A '
+        ;
+    }
+    
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -1,0 +1,154 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.Section;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@WebMvcTest(value = CourseOverTimeController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class CourseOverTimeControllerTests {
+    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeControllerTests.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Test
+    public void test_search_emptyRequest() throws Exception {
+        List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
+        String urlTemplate = "/api/public/courseovertime/search?endQuarter=%s&number=%s&startQuarter=%s&subject=%s";
+        
+        String url = String.format(urlTemplate, "20222", "156", "20221", "CMPSC");
+
+        when(convertedSectionCollection.findCourseOverTime(any(String.class), any(String.class), any(String.class)))
+            .thenReturn(expectedResult);
+
+        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+        String expcted = mapper.writeValueAsString(expectedResult);
+        
+        assertEquals(expcted, responseString);
+    }
+
+    @Test public void test_search_short() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   64")
+            .title("COMP ORGANIZATION")
+            .description("Intro to Computer Organization")
+            .build();
+        
+        Section section1 = new Section();
+        Section section2 = new Section();
+        Section section3 = new Section();
+
+        ConvertedSection course_one = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection course_two = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+        ConvertedSection couse_three = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section3)
+            .build();
+
+            String urlTemplate = "/api/public/courseovertime/search?endQuarter=%s&number=%s&startQuarter=%s&subject=%s";
+    
+            String url = String.format(urlTemplate, "20222", "64", "20221", "CMPSC");
+
+        List<ConvertedSection> expectedSections = new ArrayList<ConvertedSection>();
+        expectedSections.add(course_one);
+        expectedSections.add(course_two);
+        expectedSections.add(couse_three);
+
+        // mock
+        when(convertedSectionCollection.findCourseOverTime(any(String.class), any(String.class), eq("CMPSC    64"))).thenReturn(expectedSections);
+
+        // act
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+        // assert
+        String expectedString = mapper.writeValueAsString(expectedSections);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedString, responseString);
+    }
+
+    @Test public void test_search_long() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   130A")
+            .title("DATA STRUCT AND ALG")
+            .description("Data Structures and Algorithms")
+            .build();
+        
+        Section section1 = new Section();
+
+        Section section2 = new Section();
+
+        ConvertedSection course_one = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection course_two = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+
+        String urlTemplate = "/api/public/courseovertime/search?endQuarter=%s&number=%s&startQuarter=%s&subject=%s";
+    
+        String url = String.format(urlTemplate, "20222", "130A", "20221", "CMPSC");
+
+        System.out.println("testing two");
+        System.out.println(url);
+
+        List<ConvertedSection> expectedSections = new ArrayList<ConvertedSection>();
+        expectedSections.add(course_one);
+        expectedSections.add(course_two);
+
+        when(convertedSectionCollection.findCourseOverTime(any(String.class), any(String.class), eq("CMPSC   130A "))).thenReturn(expectedSections);
+
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+        
+        String responseString = response.getResponse().getContentAsString();
+        String expected = mapper.writeValueAsString(expectedSections);
+        assertEquals(expected, responseString);
+    }
+
+}


### PR DESCRIPTION
closes #44

file changed: ConvertedSectionCollection.java
* added a query to mongoDB that searches all the courses over a start quarter and end quarter with a specific subject and class number. 
* query returns a list of convertedSection

added CourseOverTimeController that uses query to get data from MongoDB

added CouseOverTimeControllerTests

This pr can be tested by using course-over-time-controller in swagger. Input start quarter, end quarter, subject, and number, it should return all the courses and sections that matches the inputs:
<img width="1440" alt="Screenshot 2022-11-29 at 8 38 04 PM" src="https://user-images.githubusercontent.com/86722488/204723115-d3442ffe-7075-415b-ad0e-ee70c55acfdc.png">

<img width="1440" alt="Screenshot 2022-11-29 at 8 38 08 PM" src="https://user-images.githubusercontent.com/86722488/204723094-0535b993-2afa-4bad-a37a-4294c7c4b2a0.png">

input file number should be able to search without letter i.e. input of 130A and 130 with subject CMPSC should both return courses information for CMPSC 130A

mvn test, coverage, and mutation tests all passed.

*credit to f22-5pm-courses for the function that formats courseId in the controller.*