### PR TITLE
Fixed BUG: Update Courses DataBase, First Use fails

### DIFF
--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -32,7 +32,7 @@ const UpdateCoursesJobForm = ({ callback }) => {
   );
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  const [subject, setSubject] = useState(localSubject || "");
+  const [subject, setSubject] = useState(localSubject || "ANTH");
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -32,7 +32,7 @@ const UpdateCoursesJobForm = ({ callback }) => {
   );
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  const [subject, setSubject] = useState(localSubject || {});
+  const [subject, setSubject] = useState(localSubject || "");
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -32,7 +32,7 @@ const UpdateCoursesJobForm = ({ callback }) => {
   );
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  const [subject, setSubject] = useState(localSubject || "ART");
+  const [subject, setSubject] = useState(localSubject || "ANTH");
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -32,7 +32,7 @@ const UpdateCoursesJobForm = ({ callback }) => {
   );
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  const [subject, setSubject] = useState(localSubject || "ANTH");
+  const [subject, setSubject] = useState(localSubject || "ART");
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -36,7 +36,7 @@ const AdminJobsPage = () => {
     // ***** update courses job *******
 
     const objectToAxiosParamsUpdateCoursesJob = (data) => ({
-        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${(data.subject + "")}`,
+        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.subject}`,
         method: "POST"
     });
 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -36,7 +36,7 @@ const AdminJobsPage = () => {
     // ***** update courses job *******
 
     const objectToAxiosParamsUpdateCoursesJob = (data) => ({
-        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.subject}`,
+        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.quarter}`,
         method: "POST"
     });
 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -36,7 +36,7 @@ const AdminJobsPage = () => {
     // ***** update courses job *******
 
     const objectToAxiosParamsUpdateCoursesJob = (data) => ({
-        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.quarter}`,
+        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${(data.subject + "")}`,
         method: "POST"
     });
 


### PR DESCRIPTION
Finishes up #53, now when freshly deployed, the error toast no longer pops up and the correct behavior is demonstrated.
Initially thought the error was with ```AdminJobPage.js``` handled subject data, but it was in ```UpdateCoursesJobForm```
The initial quarter is set at quarters[0], but the initial subject set a {}, which is why an Object was being passed, changed this to a string ("ANTH") so that it no longer converts Object to a String

#Before
Error on id 12, after selecting ANTH, id 13 updates ANTH correctly on 2nd try
![image](https://user-images.githubusercontent.com/72825083/204786560-9f435e2d-1c9e-4096-a738-65905c139a2e.png)

#After
![Animation](https://user-images.githubusercontent.com/72825083/204786814-5aa67e5f-868f-4e01-9673-8cb1d99c20f0.gif)
Fresh Deploy on Heroku, an error toast no longer comes up