### PR TITLE
pc - add job to update single subject over range of quarters (backend only)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -7,7 +7,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +22,8 @@ import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJob;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataOneQuarterJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataOneQuarterJobFactory;
 import edu.ucsb.cs156.courses.jobs.TestJob;
@@ -54,6 +55,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     UpdateCourseDataOneQuarterJobFactory updateCourseDataOneQuarterJobFactory;
+
+    @Autowired
+    UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -105,6 +109,22 @@ public class JobsController extends ApiController {
             start_quarterYYYYQ, end_quarterYYYYQ);
 
         return jobService.runAsJob(updateCourseDataRangeOfQuartersJob);
+    }
+
+    @ApiOperation(value = "Launch Job to Update Course Data for a range of quarters for a single subject")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/updateCoursesRangeOfQuartersSingleSubject")
+    public Job launchUpdateCourseDataRangeOfQuartersSingleSubjectJob(
+        @ApiParam("subject area") @RequestParam String subjectArea,
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String start_quarterYYYYQ,
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String end_quarterYYYYQ
+    ) {
+       
+        UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = 
+        updateCourseDataRangeOfQuartersSingleSubjectJobFactory.create(
+            subjectArea, start_quarterYYYYQ, end_quarterYYYYQ);
+
+        return jobService.runAsJob(updateCourseDataRangeOfQuartersSingleSubjectJob);
     }
 
     @ApiOperation(value = "Launch Job to Update Course Data for one quarter")

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersJob.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.courses.jobs;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
@@ -31,45 +32,54 @@ public class UpdateCourseDataRangeOfQuartersJob implements JobContextConsumer {
         for(Quarter quarter : quarters) {
             String quarterYYYYQ = quarter.getYYYYQ();
             for (String subjectArea : subjects) {
-                ctx.log("Updating courses for [" + subjectArea + " " + quarterYYYYQ + "]");
-
-                List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ,
-                        "A");
-
-                ctx.log("Found " + convertedSections.size() + " sections");
-                ctx.log("Storing in MongoDB Collection...");
-
-                int newSections = 0;
-                int updatedSections = 0;
-                int errors = 0;
-
-                for (ConvertedSection section : convertedSections) {
-                    try {
-                        String qtr = section.getCourseInfo().getQuarter();
-                        String enrollCode =  section.getSection().getEnrollCode();
-                        Optional<ConvertedSection> optionalSection = convertedSectionCollection
-                                .findOneByQuarterAndEnrollCode(qtr,enrollCode);
-                        if (optionalSection.isPresent()) {
-                            ConvertedSection existingSection = optionalSection.get();
-                            existingSection.setCourseInfo(section.getCourseInfo());
-                            existingSection.setSection(section.getSection());
-                            convertedSectionCollection.save(existingSection);
-                            updatedSections++;
-                        } else {
-                            convertedSectionCollection.save(section);
-                            newSections++;
-                        }
-                    } catch (Exception e) {
-                        ctx.log("Error saving section: " + e.getMessage());
-                        errors++;
-                    }
-                }
-            
-                ctx.log(String.format("%d new sections saved, %d sections updated, %d errors", newSections, updatedSections,
-                        errors));
-                ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
-
+                updateCourses(ctx, quarterYYYYQ, subjectArea, ucsbCurriculumService, convertedSectionCollection);
             }
         }
+    }
+
+    public static void updateCourses(
+        JobContext ctx, 
+        String quarterYYYYQ, 
+        String subjectArea, 
+        UCSBCurriculumService ucsbCurriculumService,
+        ConvertedSectionCollection convertedSectionCollection
+        ) throws JsonProcessingException {
+        ctx.log("Updating courses for [" + subjectArea + " " + quarterYYYYQ + "]");
+
+        List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ,
+                "A");
+
+        ctx.log("Found " + convertedSections.size() + " sections");
+        ctx.log("Storing in MongoDB Collection...");
+
+        int newSections = 0;
+        int updatedSections = 0;
+        int errors = 0;
+
+        for (ConvertedSection section : convertedSections) {
+            try {
+                String qtr = section.getCourseInfo().getQuarter();
+                String enrollCode =  section.getSection().getEnrollCode();
+                Optional<ConvertedSection> optionalSection = convertedSectionCollection
+                        .findOneByQuarterAndEnrollCode(qtr,enrollCode);
+                if (optionalSection.isPresent()) {
+                    ConvertedSection existingSection = optionalSection.get();
+                    existingSection.setCourseInfo(section.getCourseInfo());
+                    existingSection.setSection(section.getSection());
+                    convertedSectionCollection.save(existingSection);
+                    updatedSections++;
+                } else {
+                    convertedSectionCollection.save(section);
+                    newSections++;
+                }
+            } catch (Exception e) {
+                ctx.log("Error saving section: " + e.getMessage());
+                errors++;
+            }
+        }
+         
+        ctx.log(String.format("%d new sections saved, %d sections updated, %d errors", newSections, updatedSections,
+                errors));
+        ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJob.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import java.util.List;
+import java.util.Optional;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.models.Quarter;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJob implements JobContextConsumer {
+
+    @Getter
+    private String subjectArea;
+    @Getter
+    private String start_quarterYYYYQ;
+    @Getter
+    private String end_quarterYYYYQ;
+    @Getter
+    private UCSBCurriculumService ucsbCurriculumService;
+    @Getter
+    private ConvertedSectionCollection convertedSectionCollection;
+   
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        List<Quarter> quarters = Quarter.quarterList(Quarter.yyyyqToQyy(Integer.parseInt(start_quarterYYYYQ)),
+                Quarter.yyyyqToQyy(Integer.parseInt(end_quarterYYYYQ)));
+        for (Quarter quarter : quarters) {
+            String quarterYYYYQ = quarter.getYYYYQ();
+            UpdateCourseDataRangeOfQuartersJob.updateCourses(ctx, quarterYYYYQ, subjectArea, ucsbCurriculumService, convertedSectionCollection);
+        }
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+
+
+@Service
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory  {
+
+    @Autowired 
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @Autowired
+    private ConvertedSectionCollection convertedSectionCollection;
+
+    public UpdateCourseDataRangeOfQuartersSingleSubjectJob create(String subjectArea, String start_quarterYYYYQ, String end_quarterYYYYQ) {
+     
+        return new UpdateCourseDataRangeOfQuartersSingleSubjectJob(subjectArea, start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -37,6 +37,7 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataOneQuarterJobFactory;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
@@ -71,6 +72,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @MockBean
     UpdateCourseDataRangeOfQuartersJobFactory updateCourseDataRangeOfQuartersJobFactory;
+
+    @MockBean
+    UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
 
     @MockBean
     UpdateCourseDataOneQuarterJobFactory updateCourseDataOneQuarterJobFactory;
@@ -213,6 +217,22 @@ public class JobsControllerTests extends ControllerTestCase {
     public void admin_can_launch_update_courses_range_of_quarters_job() throws Exception {
         // act
         MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCoursesRangeOfQuarters?start_quarterYYYYQ=20221&end_quarterYYYYQ=20222").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_update_courses_range_of_quarters_single_subject_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCoursesRangeOfQuartersSingleSubject?subjectArea=CMPSC&start_quarterYYYYQ=20221&end_quarterYYYYQ=20222").with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
         // assert

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobFactoryTests.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.controllers.UCSBSubjectsController;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
+
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+@RestClientTest(UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJobFactoryTests {
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Autowired
+    UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+            
+        // Act
+        
+        UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = updateCourseDataRangeOfQuartersSingleSubjectJobFactory.create("CMPSC", "20221", "20222");
+
+        // Assert
+
+        assertEquals("CMPSC",updateCourseDataRangeOfQuartersSingleSubjectJob.getSubjectArea());
+        assertEquals("20221",updateCourseDataRangeOfQuartersSingleSubjectJob.getStart_quarterYYYYQ());
+        assertEquals("20222",updateCourseDataRangeOfQuartersSingleSubjectJob.getEnd_quarterYYYYQ());
+        assertEquals(ucsbCurriculumService,updateCourseDataRangeOfQuartersSingleSubjectJob.getUcsbCurriculumService());
+        assertEquals(convertedSectionCollection,updateCourseDataRangeOfQuartersSingleSubjectJob.getConvertedSectionCollection());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataRangeOfQuartersSingleSubjectJobTests.java
@@ -1,0 +1,93 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+//import edu.ucsb.cs156.courses.documents.Section;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class UpdateCourseDataRangeOfQuartersSingleSubjectJobTests {
+
+        @Mock
+        UCSBCurriculumService ucsbCurriculumService;
+
+        @Mock
+        ConvertedSectionCollection convertedSectionCollection;
+
+        @Mock
+        List<String> subjects;
+
+        @Test
+        void test_log_output_success() throws Exception {
+
+                // Arrange
+
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+                CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+                List<ConvertedSection> result = coursePage.convertedSections();
+
+                UpdateCourseDataRangeOfQuartersSingleSubjectJob updateCourseDataRangeOfQuartersSingleSubjectJob = new UpdateCourseDataRangeOfQuartersSingleSubjectJob(
+                                "CMPSC", "20221", "20222", ucsbCurriculumService, convertedSectionCollection);
+
+                when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20221"), eq("A"))).thenReturn(result);
+                when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20222"), eq("A"))).thenReturn(result);
+                when(convertedSectionCollection.saveAll(any())).thenReturn(result);
+
+                // Act
+
+                updateCourseDataRangeOfQuartersSingleSubjectJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating courses for [CMPSC 20221]
+                                Found 14 sections
+                                Storing in MongoDB Collection...
+                                14 new sections saved, 0 sections updated, 0 errors
+                                Courses for [CMPSC 20221] have been updated
+                                Updating courses for [CMPSC 20222]
+                                Found 14 sections
+                                Storing in MongoDB Collection...
+                                14 new sections saved, 0 sections updated, 0 errors
+                                Courses for [CMPSC 20222] have been updated""";
+
+                assertEquals(expected, jobStarted.getLog());
+
+        }
+
+     
+}


### PR DESCRIPTION
In this PR, we add a job that updates courses in the MongoDB collection for a single subject over a range of quarters.

This is helpful, for example, if we want to do a course search over a range of quarters (e.g. to find all professors that have taught CMPSC 130A over time), but we haven't updated the database for those quarters.  

